### PR TITLE
chore(): update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4988,15 +4988,6 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
-    "@types/engine.io": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.5.tgz",
-      "integrity": "sha512-DLVpLEGTEZGBXOYoYoagHSxXkDHONc0fZouF2ayw7Q18aRu1Afwci+1CFKvPpouCUOVWP+dmCaAWpQjswe7kpg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/eslint": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -5181,32 +5172,6 @@
       "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
       "requires": {
         "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "@types/socket.io": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
-      "integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
-      "dev": true,
-      "requires": {
-        "@types/engine.io": "*",
-        "@types/node": "*",
-        "@types/socket.io-parser": "*"
-      }
-    },
-    "@types/socket.io-client": {
-      "version": "1.4.35",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.35.tgz",
-      "integrity": "sha512-MI8YmxFS+jMkIziycT5ickBWK1sZwDwy16mgH/j99Mcom6zRG/NimNGQ3vJV0uX5G6g/hEw0FG3w3b3sT5OUGw==",
-      "dev": true
-    },
-    "@types/socket.io-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-2.2.1.tgz",
-      "integrity": "sha512-+JNb+7N7tSINyXPxAJb62+NcpC1x/fPn7z818W4xeNCdPTp6VsO/X8fCsg6+ug4a56m1v9sEiTIIUKVupcHOFQ==",
-      "dev": true,
-      "requires": {
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,8 +93,6 @@
     "@types/redis": "^2.8.28",
     "@types/sequelize": "^4.28.9",
     "@types/serve-static": "^1.13.9",
-    "@types/socket.io": "^2.1.13",
-    "@types/socket.io-client": "^1.4.35",
     "@types/supertest": "^2.0.10",
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.16.1",


### PR DESCRIPTION
Removing these two types:
 - `@types/socket.io`
 -  `@types/socket.io-client` 
no longer gives this error(see screenshot):
<img width="1285" alt="screenshot" src="https://user-images.githubusercontent.com/11542387/147701820-94214a73-ab37-408b-b327-123f78f7753b.png">


doing `npm run start:dev` in the project root