### PR TITLE
refactor(primsa-sample): generics types in mock functions

### DIFF
--- a/apps/prisma-sample/src/cat/cat.dto.ts
+++ b/apps/prisma-sample/src/cat/cat.dto.ts
@@ -19,3 +19,5 @@ export class CatDTO {
   @Validate(OwnerExistsRule)
   ownerId: string;
 }
+
+export type TCat = CatDTO & { id: string };


### PR DESCRIPTION
- refactor mock functions generic types in ```cat.controller.spec.ts```
- added ```TCat``` type in ```cat.dto.ts```
